### PR TITLE
Use ninja-base instead of ninja to avoid the dependency on python

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 98e9c3d949d1b924e28e01eccb7deed865eefebf25c2f21c702e5cd5b63b85e1
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win and vc<14]
   run_exports:
     # pretty bad removal of symbols in every other micro release:
@@ -23,7 +23,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - msinttypes    # [win]
-    - ninja
+    - ninja-base
     - make          # [unix]
     # Require `cmake-no-system` to break circular dependency;
     # the `cmake` package on defaults requires `zstd`.


### PR DESCRIPTION
zstd 1.5.5 build 2

**Destination channel:** defaults

### Explanation of changes:

Simply switching to ninja-base. This avoids a dependency on Python at build time. Considering that zstd is quite low-level, the dependency on Python makes it complicated to bootstrap our environment.
