### PR TITLE
Update/v1.5.6

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+c_compiler:          # [osx]
+  - clang_bootstrap  # [osx]
+cxx_compiler:        # [osx]
+  - clang_bootstrap  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://github.com/facebook/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: 30f35f71c1203369dc979ecde0400ffea93c27391bfd2ac5a9715d2173d92ff7
+  patches:
+    - patches/4019.patch
 
 build:
   number: 0
@@ -28,6 +30,8 @@ requirements:
     # Require `cmake-no-system` to break circular dependency;
     # the `cmake` package on defaults requires `zstd`.
     - cmake-no-system
+    - patch  # [unix]
+    - m2-patch  # [win]
   host:
     - zlib
     - lz4-c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "zstd" %}
-{% set version = "1.5.5" %}
+{% set version = "1.5.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/facebook/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 98e9c3d949d1b924e28e01eccb7deed865eefebf25c2f21c702e5cd5b63b85e1
+  sha256: 30f35f71c1203369dc979ecde0400ffea93c27391bfd2ac5a9715d2173d92ff7
 
 build:
-  number: 2
+  number: 0
   skip: True  # [win and vc<14]
   run_exports:
     # pretty bad removal of symbols in every other micro release:

--- a/recipe/patches/4019.patch
+++ b/recipe/patches/4019.patch
@@ -1,0 +1,22 @@
+From fd5f8106a58601a963ee816e6a57aa7c61fafc53 Mon Sep 17 00:00:00 2001
+From: BadWolf <b7f7@gmx.de>
+Date: Sat, 6 Apr 2024 00:05:58 +0200
+Subject: [PATCH] fix missing include folder for resource compiler
+
+---
+ build/cmake/lib/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build/cmake/lib/CMakeLists.txt b/build/cmake/lib/CMakeLists.txt
+index 5d514ccb2e..43b14d1753 100644
+--- a/build/cmake/lib/CMakeLists.txt
++++ b/build/cmake/lib/CMakeLists.txt
+@@ -118,7 +118,7 @@ endmacro ()
+ 
+ # Define directories containing the library's public headers
+ set(PUBLIC_INCLUDE_DIRS ${LIBRARY_DIR})
+-
++set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} /I ${LIBRARY_DIR}")
+ # Split project to static and shared libraries build
+ set(library_targets)
+ if (ZSTD_BUILD_SHARED)


### PR DESCRIPTION
zstd v1.5.6
**Destination channel:**  defaults

### Links

- [PKG-5314](https://anaconda.atlassian.net/browse/PKG-5314) 
- [Upstream repository](https://github.com/facebook/zstd/tree/v1.5.6)
- [Upstream changelog/diff](https://github.com/facebook/zstd/blob/v1.5.6/CHANGELOG)
- Relevant dependency PRs:
  - This is needed to update https://github.com/AnacondaRecipes/zstandard-feedstock

### Explanation of changes:

- Fix overdepending on OSX by only including the `clang_bootstrap` compiler
- Add [upstream patch](https://github.com/facebook/zstd/pull/4019) in order to fix build issue on Windows. 


[PKG-5314]: https://anaconda.atlassian.net/browse/PKG-5314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ